### PR TITLE
Apple Silicon: noraneko-ci の .app tar.xz を runtime として飲む

### DIFF
--- a/tools/src/defines.ts
+++ b/tools/src/defines.ts
@@ -139,6 +139,12 @@ export type BinArchive =
       format: "dmg";
       platform: "darwin";
       architecture: "universal";
+    }
+  | {
+      filename: string;
+      format: "tar.xz";
+      platform: "darwin";
+      architecture: "aarch64";
     };
 
 export function getBinArchive(): BinArchive {
@@ -163,6 +169,16 @@ export function getBinArchive(): BinArchive {
   }
 
   if (PLATFORM === "darwin") {
+    // Apple Silicon は noraneko-ci(aarch64 Linux から cross)が出す .app の tar.xz。
+    // universal dmg は Intel 向けの旧形式(旧 release にしか無い)。
+    if (Deno.build.arch === "aarch64") {
+      return {
+        filename: `${BRANDING.base_name}-macos-aarch64-moz-artifact.tar.xz`,
+        format: "tar.xz",
+        platform: "darwin",
+        architecture: "aarch64",
+      };
+    }
     return {
       filename: `${BRANDING.base_name}-macOS-universal-moz-artifact.dmg`,
       format: "dmg",

--- a/tools/src/initializer.ts
+++ b/tools/src/initializer.ts
@@ -17,8 +17,12 @@ import {
 } from "./defines.ts";
 import { Logger, runCommand, exists, safeRemove } from "./utils.ts";
 
-const NORANEKO_RUNTIME_BASE =
-  "https://github.com/f3liz-dev/noraneko-runtime/releases/latest/download";
+// NORANEKO_RUNTIME_TAG=passed-20260902074154 のように tag を指すと prerelease も飲める。
+// 未指定なら latest(prerelease は含まれない)。
+const NORANEKO_RUNTIME_TAG = Deno.env.get("NORANEKO_RUNTIME_TAG");
+const NORANEKO_RUNTIME_BASE = NORANEKO_RUNTIME_TAG
+  ? `https://github.com/f3liz-casa/noraneko-runtime/releases/download/${NORANEKO_RUNTIME_TAG}`
+  : "https://github.com/f3liz-casa/noraneko-runtime/releases/latest/download";
 
 const logger = new Logger("initializer");
 
@@ -215,9 +219,21 @@ export async function decompressBin(): Promise<void> {
           throw new Error("Non-zip archives not supported on Windows");
 
         case "darwin": {
-          logger.info("macOS extraction (hdiutil)");
           const destDir = path.join(BIN_ROOT_DIR, BRANDING.base_name);
           Deno.mkdirSync(destDir, { recursive: true });
+          if (archivePath.endsWith(".tar.xz")) {
+            // aarch64 の .app が tar.xz で来る(中身は Noraneko.app/ 一つ)
+            logger.info("macOS extraction (tar.xz)");
+            runCommand("tar", ["-xJf", archivePath, "-C", destDir]);
+            try {
+              runCommand("xattr", ["-rc", destDir]);
+            } catch {
+              // xattr might not be present; ignore
+            }
+            runCommand("chmod", ["-R", "755", destDir]);
+            break;
+          }
+          logger.info("macOS extraction (hdiutil)");
           const mountPoint = await Deno.makeTempDir({
             prefix: "nora_dmg_mount_",
           });

--- a/tools/src/initializer.ts
+++ b/tools/src/initializer.ts
@@ -222,15 +222,19 @@ export async function decompressBin(): Promise<void> {
           const destDir = path.join(BIN_ROOT_DIR, BRANDING.base_name);
           Deno.mkdirSync(destDir, { recursive: true });
           if (archivePath.endsWith(".tar.xz")) {
-            // aarch64 の .app が tar.xz で来る(中身は Noraneko.app/ 一つ)
+            // aarch64 の .app は mach package(TAR)の staging: noraneko/Noraneko.app/…
+            // linux と同じく BIN_ROOT_DIR に展開すると destDir/Noraneko.app になる。
             logger.info("macOS extraction (tar.xz)");
-            runCommand("tar", ["-xJf", archivePath, "-C", destDir]);
+            runCommand("tar", ["-xJf", archivePath, "-C", BIN_ROOT_DIR]);
             try {
               runCommand("xattr", ["-rc", destDir]);
             } catch {
               // xattr might not be present; ignore
             }
             runCommand("chmod", ["-R", "755", destDir]);
+            // Linux で cross した bundle は無署名。Apple Silicon は署名が無いと
+            // dyld が libxul を拒む("Couldn't load XPCOM")ので ad-hoc で署名する。
+            runCommand("codesign", ["--force", "--deep", "--sign", "-", APP_DIR]);
             break;
           }
           logger.info("macOS extraction (hdiutil)");

--- a/tools/src/initializer.ts
+++ b/tools/src/initializer.ts
@@ -17,12 +17,48 @@ import {
 } from "./defines.ts";
 import { Logger, runCommand, exists, safeRemove } from "./utils.ts";
 
-// NORANEKO_RUNTIME_TAG=passed-20260902074154 のように tag を指すと prerelease も飲める。
-// 未指定なら latest(prerelease は含まれない)。
+// runtime の置き場(GitHub release)。
+// - NORANEKO_RUNTIME_TAG=passed-20260902074154 のように tag を指せば、その release(prerelease でも)。
+// - 未指定なら latest。ただし Apple Silicon の tar.xz は platform が揃うまで prerelease にしか無いので、
+//   その資産を持つ一番新しい release を API で探す(無ければ latest に落ちて、404 で分かる)。
+const NORANEKO_RUNTIME_REPO = "f3liz-casa/noraneko-runtime";
 const NORANEKO_RUNTIME_TAG = Deno.env.get("NORANEKO_RUNTIME_TAG");
-const NORANEKO_RUNTIME_BASE = NORANEKO_RUNTIME_TAG
-  ? `https://github.com/f3liz-casa/noraneko-runtime/releases/download/${NORANEKO_RUNTIME_TAG}`
-  : "https://github.com/f3liz-casa/noraneko-runtime/releases/latest/download";
+let runtimeBaseCache: string | undefined;
+async function runtimeBase(filename: string): Promise<string> {
+  if (runtimeBaseCache) return runtimeBaseCache;
+  const dl = (tag: string) =>
+    `https://github.com/${NORANEKO_RUNTIME_REPO}/releases/download/${tag}`;
+  if (NORANEKO_RUNTIME_TAG) {
+    runtimeBaseCache = dl(NORANEKO_RUNTIME_TAG);
+  } else {
+    runtimeBaseCache =
+      `https://github.com/${NORANEKO_RUNTIME_REPO}/releases/latest/download`;
+    if (PLATFORM === "darwin" && Deno.build.arch === "aarch64") {
+      try {
+        const resp = await fetch(
+          `https://api.github.com/repos/${NORANEKO_RUNTIME_REPO}/releases?per_page=30`,
+          { headers: { accept: "application/vnd.github+json" } },
+        );
+        if (resp.ok) {
+          const releases = (await resp.json()) as {
+            tag_name: string;
+            assets: { name: string }[];
+          }[];
+          const hit = releases.find((r) =>
+            r.assets.some((a) => a.name === filename)
+          );
+          if (hit) {
+            logger.info(`Runtime release with ${filename}: ${hit.tag_name}`);
+            runtimeBaseCache = dl(hit.tag_name);
+          }
+        }
+      } catch {
+        // API に届かなければ latest のまま
+      }
+    }
+  }
+  return runtimeBaseCache;
+}
 
 const logger = new Logger("initializer");
 
@@ -182,7 +218,7 @@ export async function decompressBin(): Promise<void> {
   const binArchive = STOCK_FIREFOX ? getStockArchive() : getBinArchive();
   const downloadUrl = STOCK_FIREFOX
     ? (binArchive as { url: string }).url
-    : `${NORANEKO_RUNTIME_BASE}/${binArchive.filename}`;
+    : `${await runtimeBase(binArchive.filename)}/${binArchive.filename}`;
   logger.info(
     `Binary extraction started: ${binArchive.filename}` +
       (STOCK_FIREFOX ? " (stock Firefox)" : ""),
@@ -346,7 +382,7 @@ function deoptimizeOmni(omniPath: string): void {
 }
 
 export async function downloadBin(filename: string, url?: string): Promise<void> {
-  const downloadUrl = url ?? `${NORANEKO_RUNTIME_BASE}/${filename}`;
+  const downloadUrl = url ?? `${await runtimeBase(filename)}/${filename}`;
   logger.info(`Downloading binary from ${downloadUrl}`);
 
   const resp = await fetch(downloadUrl);
@@ -368,7 +404,8 @@ export async function downloadBin(filename: string, url?: string): Promise<void>
  * No-op unless darwin + STOCK_FIREFOX.
  */
 export function resignMacApp(): void {
-  if (PLATFORM !== "darwin" || !STOCK_FIREFOX) {
+  // runtime の tar.xz(Apple Silicon)も ad-hoc 署名で来るので、omni.ja を直したあとは同じく結び直す
+  if (PLATFORM !== "darwin" || !(STOCK_FIREFOX || Deno.build.arch === "aarch64")) {
     return;
   }
   logger.info(`Ad-hoc re-signing ${APP_DIR} ...`);

--- a/tools/src/initializer.ts
+++ b/tools/src/initializer.ts
@@ -17,23 +17,43 @@ import {
 } from "./defines.ts";
 import { Logger, runCommand, exists, safeRemove } from "./utils.ts";
 
-// runtime の置き場(GitHub release)。
-// - NORANEKO_RUNTIME_TAG=passed-20260902074154 のように tag を指せば、その release(prerelease でも)。
-// - 未指定なら latest。ただし Apple Silicon の tar.xz は platform が揃うまで prerelease にしか無いので、
-//   その資産を持つ一番新しい release を API で探す(無ければ latest に落ちて、404 で分かる)。
+// runtime の取り先。
+// 1. NORANEKO_RUNTIME_TAG=passed-20260902074154 のように tag を指せば GitHub release のその tag。
+// 2. 無ければ dl.f3liz.casa(noraneko-ci の産物、B2)。/latest/<target> が最新の sha へ 302 する。
+// 3. dl に無ければ GitHub release。Apple Silicon の tar.xz は platform が揃うまで prerelease にしか無いので、
+//    その資産を持つ一番新しい release を API で探し、無ければ latest。
 const NORANEKO_RUNTIME_REPO = "f3liz-casa/noraneko-runtime";
+const NORANEKO_DL = "https://dl.f3liz.casa/noraneko-runtime";
 const NORANEKO_RUNTIME_TAG = Deno.env.get("NORANEKO_RUNTIME_TAG");
-let runtimeBaseCache: string | undefined;
-async function runtimeBase(filename: string): Promise<string> {
-  if (runtimeBaseCache) return runtimeBaseCache;
-  const dl = (tag: string) =>
-    `https://github.com/${NORANEKO_RUNTIME_REPO}/releases/download/${tag}`;
+const urlCache = new Map<string, string>();
+async function runtimeUrl(filename: string): Promise<string> {
+  const cached = urlCache.get(filename);
+  if (cached) return cached;
+  const gh = (tag: string) =>
+    `https://github.com/${NORANEKO_RUNTIME_REPO}/releases/download/${tag}/${filename}`;
+  let url = `https://github.com/${NORANEKO_RUNTIME_REPO}/releases/latest/download/${filename}`;
   if (NORANEKO_RUNTIME_TAG) {
-    runtimeBaseCache = dl(NORANEKO_RUNTIME_TAG);
+    url = gh(NORANEKO_RUNTIME_TAG);
   } else {
-    runtimeBaseCache =
-      `https://github.com/${NORANEKO_RUNTIME_REPO}/releases/latest/download`;
-    if (PLATFORM === "darwin" && Deno.build.arch === "aarch64") {
+    const target = PLATFORM === "darwin"
+      ? `macos-${Deno.build.arch}`
+      : PLATFORM === "linux"
+      ? `linux-${Deno.build.arch}`
+      : undefined;
+    let found = false;
+    if (target) {
+      try {
+        const head = await fetch(`${NORANEKO_DL}/latest/${target}`, { method: "HEAD" });
+        if (head.ok) {
+          logger.info(`Runtime from dl.f3liz.casa: ${head.url}`);
+          url = head.url;
+          found = true;
+        }
+      } catch {
+        // dl に届かなければ GitHub へ
+      }
+    }
+    if (!found && PLATFORM === "darwin" && Deno.build.arch === "aarch64") {
       try {
         const resp = await fetch(
           `https://api.github.com/repos/${NORANEKO_RUNTIME_REPO}/releases?per_page=30`,
@@ -49,7 +69,7 @@ async function runtimeBase(filename: string): Promise<string> {
           );
           if (hit) {
             logger.info(`Runtime release with ${filename}: ${hit.tag_name}`);
-            runtimeBaseCache = dl(hit.tag_name);
+            url = gh(hit.tag_name);
           }
         }
       } catch {
@@ -57,7 +77,8 @@ async function runtimeBase(filename: string): Promise<string> {
       }
     }
   }
-  return runtimeBaseCache;
+  urlCache.set(filename, url);
+  return url;
 }
 
 const logger = new Logger("initializer");
@@ -218,7 +239,7 @@ export async function decompressBin(): Promise<void> {
   const binArchive = STOCK_FIREFOX ? getStockArchive() : getBinArchive();
   const downloadUrl = STOCK_FIREFOX
     ? (binArchive as { url: string }).url
-    : `${await runtimeBase(binArchive.filename)}/${binArchive.filename}`;
+    : await runtimeUrl(binArchive.filename);
   logger.info(
     `Binary extraction started: ${binArchive.filename}` +
       (STOCK_FIREFOX ? " (stock Firefox)" : ""),
@@ -382,7 +403,7 @@ function deoptimizeOmni(omniPath: string): void {
 }
 
 export async function downloadBin(filename: string, url?: string): Promise<void> {
-  const downloadUrl = url ?? `${await runtimeBase(filename)}/${filename}`;
+  const downloadUrl = url ?? await runtimeUrl(filename);
   logger.info(`Downloading binary from ${downloadUrl}`);
 
   const resp = await fetch(downloadUrl);


### PR DESCRIPTION
Apple Silicon の Mac で `deno task feles-build dev` が動くようにします。

- runtime は noraneko-ci(aarch64 Linux から cross)が出す `noraneko-macos-aarch64-moz-artifact.tar.xz`(mach package の TAR staging、`noraneko/Noraneko.app`)。universal dmg は旧 release にしか無い Intel 向けの形なので、arm64 では tar.xz を選びます。
- Linux で cross した bundle は無署名で、arm64 は署名が無いと libxul を拒む("Couldn't load XPCOM")ので、展開時と、omni.ja を直したあとに ad-hoc で署名します(`resignMacApp` を runtime の道にも)。
- 取り先は順に: `NORANEKO_RUNTIME_TAG`(GitHub release の tag)→ **dl.f3liz.casa**(noraneko-ci の産物。`/noraneko-runtime/latest/<target>` が最新の sha へ 302)→ GitHub release(tar.xz を持つ一番新しいもの、無ければ latest)。
- この Mac(M 系)で tar と `_dist/bin` を消してから dev を通し、dl から 155.0.1 を落として、展開 → 署名 → patch → 起動(GPU helper 込み)まで確認しました。

コミットは全部 GPG 署名済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwrruLhyKKN7A1iLU4YLdL