### PR TITLE
dev を、他の人も立ち上げられるように(mac arm64 / Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For developers and contributors, see the following documentation:
 
 | Document | Description |
 |----------|-------------|
+| [Development](docs/DEV.md) | Getting a dev browser running (macOS arm64 / Linux) |
 | [Architecture](docs/ARCHITECTURE.md) | High-level architecture overview |
 | [Build System](docs/BUILD_SYSTEM.md) | Build system and tooling documentation |
 | [Event Dispatcher](docs/RPC_SYSTEM_README.md) | Inter-module communication system |

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,111 @@
+# Running Noraneko in development
+
+Two commands, on macOS (Apple Silicon) or Linux. Everything else — the Firefox
+runtime, the profile, the build output — is downloaded or generated under
+`_dist/`, and nothing is installed system-wide.
+
+## What you need
+
+- **git**
+- **[mise](https://mise.jdx.dev)** — pins the toolchain in `mise.toml`
+  (deno 2.9.6, ruby 3.4). If you would rather not use mise, install those two
+  yourself; nothing else is required.
+- **~3 GB** of free disk (runtime archive + extracted runtime + build output)
+- `tar` with xz support (standard on both platforms)
+- macOS only: the Xcode Command Line Tools, for `codesign` and `xattr`
+  (`xcode-select --install`). The runtime is cross-built and unsigned, so it is
+  ad-hoc signed on extraction — without it, macOS refuses to load XPCOM.
+
+No Node, no pnpm: the npm packages are resolved by Deno.
+
+## Start it
+
+```sh
+mise install
+mise exec -- deno task feles-build dev
+```
+
+`mise install` only *installs* the tools — it does not put them on your `PATH`.
+Either keep the `mise exec --` prefix, or activate mise in your shell once
+(`eval "$(mise activate bash)"`, `zsh`, …) and then just
+`deno task feles-build dev`.
+
+### What the first run does
+
+1. **Downloads the runtime** (~66 MB): a Firefox build for your platform, from
+   `dl.f3liz.casa` (the noraneko-runtime CI), falling back to GitHub releases.
+   It is cached as `noraneko-<platform>-<arch>-moz-artifact.tar.xz` in the repo
+   root, so the next run does not download again.
+2. **Extracts** it into `_dist/bin/` (and ad-hoc signs the `.app` on macOS).
+3. **Patches, builds and injects** the browser features into that runtime.
+4. **Starts the Vite dev servers** (HMR) and **launches the browser** with a dev
+   profile at `_dist/profile/test` and remote debugging (BiDi) on **5180**.
+
+Closing the browser window stops the dev servers and ends the task.
+
+## Platforms
+
+| Platform | State |
+|---|---|
+| macOS arm64 (Apple Silicon) | **Works.** Verified from a clean clone, 2026-09-12. |
+| Linux aarch64 | **Should work.** A current runtime is published and its layout is the one the tooling expects; we have not yet run it end to end on a Linux machine. Please tell us how it goes. |
+| Linux x86_64 | **No current runtime.** The CI builder is aarch64, so the newest x86_64 artifact is from 2025-09 (`passed-20250917142938`) and will drift from the code here. You can still try it by pinning that tag (below). |
+| Windows x86_64 | Same as Linux x86_64: only the 2025-09 artifact. |
+
+If your platform has no runtime, the download step stops and says so, rather
+than leaving you with a broken extract.
+
+### Pinning a particular runtime
+
+```sh
+NORANEKO_RUNTIME_TAG=passed-20260902074154 mise exec -- deno task feles-build dev
+```
+
+Tags are the releases of
+[f3liz-casa/noraneko-runtime](https://github.com/f3liz-casa/noraneko-runtime).
+Delete the cached `noraneko-*-moz-artifact.tar.xz` (and `_dist/bin`) when you
+switch.
+
+## Where things are
+
+| Path | What |
+|---|---|
+| `_dist/bin/` | the runtime (`Noraneko.app` on macOS, `noraneko/` on Linux) |
+| `_dist/profile/test/` | the dev profile |
+| `_dist/buildid2` | build id of the current dev build |
+| `logs/vite-*.log` | dev server logs |
+| 5180 | BiDi / remote debugging |
+
+## When something goes wrong
+
+- **`deno: command not found`** — `mise install` installed it, but your shell
+  does not see it. Use `mise exec -- …` or activate mise.
+- **The browser closes right after launching** (`[launcher] Browser Closed`
+  immediately) — another Noraneko is already running on the same profile, so
+  your new process handed over to it and exited. Close that one, or launch by
+  hand with a different profile and port:
+
+  ```sh
+  # macOS
+  _dist/bin/noraneko/Noraneko.app/Contents/MacOS/noraneko \
+    --profile /tmp/nora-profile --remote-debugging-port 5190 \
+    --remote-allow-system-access --no-remote
+  # Linux
+  _dist/bin/noraneko/noraneko \
+    --profile /tmp/nora-profile --remote-debugging-port 5190 \
+    --remote-allow-system-access --no-remote
+  ```
+
+  (That runs the already-built runtime; it does not rebuild.)
+- **`HTTP 404` while downloading the runtime** — your platform has no build
+  published yet. See the table above.
+- **macOS: "Couldn't load XPCOM"** — the bundle lost its ad-hoc signature
+  (usually after being copied or modified by hand). Remove `_dist/bin` and run
+  dev again.
+- **Stale Vite servers** — the launcher kills leftovers from a previous run and
+  says so in the log; that line is expected, not an error.
+
+## Next
+
+- [Build System](BUILD_SYSTEM.md) — what each step above actually does
+- [Architecture](ARCHITECTURE.md) — how the pieces fit together

--- a/tools/src/initializer.ts
+++ b/tools/src/initializer.ts
@@ -20,8 +20,12 @@ import { Logger, runCommand, exists, safeRemove } from "./utils.ts";
 // runtime の取り先。
 // 1. NORANEKO_RUNTIME_TAG=passed-20260902074154 のように tag を指せば GitHub release のその tag。
 // 2. 無ければ dl.f3liz.casa(noraneko-ci の産物、B2)。/latest/<target> が最新の sha へ 302 する。
-// 3. dl に無ければ GitHub release。Apple Silicon の tar.xz は platform が揃うまで prerelease にしか無いので、
-//    その資産を持つ一番新しい release を API で探し、無ければ latest。
+// 3. dl に無ければ GitHub release。**その資産を持つ一番新しい release を API で探す**
+//    ── 新しい platform は、揃うまで prerelease にしか無いことがある(`latest` は
+//    その platform を持たないまま古くなる)。見つからなければ latest に任せる。
+//
+// どこにも無い platform は、そこで止めて**何が無いのか**を言う。黙って 404 の
+// bytes を書いて、あとで tar が転ぶより、そのほうが分かる。
 const NORANEKO_RUNTIME_REPO = "f3liz-casa/noraneko-runtime";
 const NORANEKO_DL = "https://dl.f3liz.casa/noraneko-runtime";
 const NORANEKO_RUNTIME_TAG = Deno.env.get("NORANEKO_RUNTIME_TAG");
@@ -45,6 +49,9 @@ async function runtimeUrl(filename: string): Promise<string> {
       try {
         const head = await fetch(`${NORANEKO_DL}/latest/${target}`, { method: "HEAD" });
         if (head.ok) {
+          // dl が返す名前は、いつも moz-artifact とは限らない(linux は package した
+          // ほうの名前で置かれていることがある)。中の形は同じ(`<base_name>/…`)なので
+          // そのまま使うけれど、**実際に取ったものの名前は出す**
           logger.info(`Runtime from dl.f3liz.casa: ${head.url}`);
           url = head.url;
           found = true;
@@ -53,7 +60,9 @@ async function runtimeUrl(filename: string): Promise<string> {
         // dl に届かなければ GitHub へ
       }
     }
-    if (!found && PLATFORM === "darwin" && Deno.build.arch === "aarch64") {
+    if (!found) {
+      // その資産を持つ、一番新しい release。platform が揃うまで prerelease にしか
+      // 無いことがあるので、`latest` だけを見ない(darwin に限らず、どの platform も)
       try {
         const resp = await fetch(
           `https://api.github.com/repos/${NORANEKO_RUNTIME_REPO}/releases?per_page=30`,
@@ -62,14 +71,25 @@ async function runtimeUrl(filename: string): Promise<string> {
         if (resp.ok) {
           const releases = (await resp.json()) as {
             tag_name: string;
+            prerelease?: boolean;
+            published_at?: string;
             assets: { name: string }[];
           }[];
           const hit = releases.find((r) =>
             r.assets.some((a) => a.name === filename)
           );
           if (hit) {
-            logger.info(`Runtime release with ${filename}: ${hit.tag_name}`);
+            logger.info(
+              `Runtime release with ${filename}: ${hit.tag_name}` +
+                (hit.published_at ? ` (${hit.published_at.slice(0, 10)})` : ""),
+            );
             url = gh(hit.tag_name);
+            found = true;
+          } else {
+            logger.warn(
+              `No release in the last 30 has ${filename} — ` +
+                `this platform may not be built yet. See docs/DEV.md.`,
+            );
           }
         }
       } catch {
@@ -408,7 +428,15 @@ export async function downloadBin(filename: string, url?: string): Promise<void>
 
   const resp = await fetch(downloadUrl);
   if (!resp.ok) {
-    throw new Error(`HTTP error ${resp.status}`);
+    // ここで止まるのは、たいてい「この platform の runtime が、まだどこにも
+    // 置かれていない」とき。何が無いのかと、どうすれば進めるのかを言う
+    throw new Error(
+      `HTTP ${resp.status} for ${downloadUrl}\n` +
+        `  ${filename} (${PLATFORM}/${Deno.build.arch}) がどこにも見つからない。\n` +
+        `  持っている tag を指すなら: NORANEKO_RUNTIME_TAG=<tag> deno task feles-build dev\n` +
+        `  置いてあるものの一覧: https://github.com/${NORANEKO_RUNTIME_REPO}/releases\n` +
+        `  どの platform が今あるのかは docs/DEV.md`,
+    );
   }
   const data = new Uint8Array(await resp.arrayBuffer());
   await Deno.writeFile(filename, data);


### PR DESCRIPTION
いまは「知っている人だけが立てられる」状態でした。README に dev の入口が無く、
`mise install` だけでは deno が PATH に来ないので初手で `deno: command not found`
になります(自分で踏みました)。runtime がまだ無い platform では、404 の bytes を
書いてから tar が転びます。

## `docs/DEV.md`(README からリンク)

要るもの(git / mise / 3GB / mac は Xcode CLT ── cross build は無署名なので ad-hoc
署名に codesign が要る)、二つのコマンド、初回に何が起きるか、置き場所と 5180、
困ったときの四つ。**node も pnpm も要りません**(npm の物は deno が解く)。

platform の表は、正直に:

| platform | いま |
|---|---|
| macOS arm64 | **動く。** まっさらな clone から一周して確かめた(2026-09-12) |
| Linux aarch64 | **動くはず。** runtime は置かれていて、中の形(`noraneko/noraneko-bin` / `libxul.so` / `application.ini`)も道具が待っているとおり。**Linux 実機では、まだ誰も一周していない** |
| Linux x86_64 | **いまの runtime が無い。** CI の箱が aarch64 なので、一番新しい x86_64 は 2025-09(`passed-20250917142938`)。tag を指せば試せるが、コードとずれる |
| Windows x86_64 | 同上 |

## runtime の探しかた(`tools/src/initializer.ts`)

- 「その資産を持つ一番新しい release を API で探す」が **darwin 限定**でした。
  どの platform でも通るように。新しい platform は揃うまで prerelease にしか
  無いので、`latest` だけ見ていると落ちます。これで **Linux aarch64 は
  `passed-20260902074154` に当たります**。
- **どこにも無いときは、そこで止めて言う。** 何が(filename と platform/arch)
  無いのか、`NORANEKO_RUNTIME_TAG` の指しかた、release 一覧、docs/DEV.md。
  前は `HTTP error 404` の一行だけでした。
- dl が返す名前が moz-artifact とは限らない(linux は package したほうの名前で
  置かれていることがある)のは、そのまま使います ── 中の形は同じで、取ったものの
  名前はログに出ます。

## 確かめたこと

- この worktree で `mise exec -- deno task feles-build dev` を一周
  (落として、展開して、署名して、patch して、build して、launch まで)
- その前に、`/tmp` へまっさらに clone しても同じところまで通ることを確認
- Linux の tarball は**中身の一覧だけ**(実機は無いので)。道具が見に行く path が
  そのまま入っていることを確認

## 残り(このあと)

**Linux x86_64 の runtime を CI が出すこと。** `noraneko-runtime` の
`.github/workflows/mozconfigs/linux-x86_64.mozconfig` はもう有って、daily
(`bsys6-daily-build.yml`)が linux-aarch64 と macos-aarch64 の二つしか建てて
いないだけです。aarch64 の job を写して `ARCH=x86_64` にするのが次の一歩かと。

あと、**Linux 実機での一周**は誰かの手が要ります。DEV.md には、そう書いてあります。

## 気になるところ

- **落としたものを、誰も照らしていない。** `SHA256SUMS` は GitHub の release には
  有りますが dl には無く、`initializer.ts` は hash を見ずに展開します。自分たちだけなら
  気になりませんが、「他の人も使う」にすると、ここが一番やわらかいところです
  (drops 側は sha256 と判を照らしているので、形も揃っていません)。**別の一本で**、
  `SHA256SUMS` の突き合わせと、`latest` ではなく sha で pin できる口を足すつもりです。
- base は `main` ではなく `rftr-bridge`(この repo の既定枝)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwrruLhyKKN7A1iLU4YLdL
