### PR TITLE
手元で動かすための画面と、開発用 Noraneko を閉じる口(配ったものは掴まない)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -41,6 +41,7 @@
   ],
   "tasks": {
     "feles-build": "ruby tools/feles-build.rb",
+    "launcher": "ruby tools/launcher.rb",
     "drop:build": "ruby tools/scripts/build-drop.rb",
     "gha:dev": "gaji dev",
     "gha:build": "gaji build"

--- a/deno.json
+++ b/deno.json
@@ -42,6 +42,7 @@
   "tasks": {
     "feles-build": "ruby tools/feles-build.rb",
     "launcher": "ruby tools/launcher.rb",
+    "test:tools": "ruby tools/test/dev_browser_test.rb",
     "drop:build": "ruby tools/scripts/build-drop.rb",
     "gha:dev": "gaji dev",
     "gha:build": "gaji build"

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -32,6 +32,7 @@ This runs `tools/feles-build.rb`, which orchestrates the entire build process.
 | `dev` | Development workflow - downloads binary, applies patches, builds in dev mode, starts dev servers, launches browser |
 | `stage` | Production build with dev-mode browser launch - useful for testing production assets |
 | `build --phase <phase>` | Production build for CI (phases: `before-mach`, `after-mach`) |
+| `stop` | Close the dev browser started from this checkout |
 | `misc patch --action <action>` | Patch management (actions: `apply`, `create`, `init`) |
 | `misc writeVersion` | Write version files for Gecko |
 
@@ -168,7 +169,23 @@ resource noraneko resource/ contentaccessible=yes
 
 **Logs:** Written to `logs/vite-*.log`
 
-### 7. Browser Launcher (`browser_launcher.rb`)
+### 7. Browser Launcher (`browser_launcher.rb`, with `dev_browser.rb`)
+
+**Closing the dev browser (`stop`).** Firefox hands a profile to whoever already holds it,
+so a dev browser left running from an earlier session silently swallows the next `dev` run —
+the new process starts, hands off, and exits. `deno task feles-build stop` closes it.
+
+Because this kills a browser, `DevBrowser` decides what it may touch from the narrow side.
+A process is closed only if **both** locks pass:
+
+1. its executable is under this checkout's `_dist/bin/`, and
+2. its `--profile` is exactly this checkout's `_dist/profile/test`.
+
+Both paths are built from `PROJECT_ROOT`, so an installed Noraneko — living outside the
+checkout and using the user's own profile — can never match either. A second lock is not
+redundant: a Noraneko started *from this checkout* with a different profile is left alone
+too. `tools/test/dev_browser_test.rb` pins this; if you ever loosen the rule, add a case there.
+
 
 **Purpose:** Launches the Noraneko browser with debugging enabled.
 

--- a/tools/feles-build.rb
+++ b/tools/feles-build.rb
@@ -11,6 +11,7 @@ abort "ruby #{RUBY_VERSION} は古い(3.1 以上が要る)。`mise install` で 
 
 require_relative "lib/browser_launcher"
 require_relative "lib/builder"
+require_relative "lib/dev_browser"
 require_relative "lib/dev_env_manager"
 require_relative "lib/dev_server"
 require_relative "lib/initializer"
@@ -32,6 +33,7 @@ module FelesBuild
       dev        Run the development workflow
       stage      Build production assets and run browser in dev mode
       build      Run the production build workflow (--phase before-mach|after-mach)
+      stop       Close the dev browser started from this checkout
       misc       Misc commands (e.g. 'misc patch --action apply', 'misc writeVersion')
   TXT
 
@@ -118,6 +120,7 @@ module FelesBuild
       prepare("stage")
       serve_and_launch
     when "build" then run_build(flag(argv, "--phase"))
+    when "stop" then DevBrowser.stop
     when "misc" then run_misc(argv)
     when "--help", "-h", nil then puts USAGE
     else

--- a/tools/launcher.rb
+++ b/tools/launcher.rb
@@ -19,6 +19,7 @@ COMMANDS = {
   "dev" => %w[dev],
   "stage" => %w[stage],
   "before-mach" => %w[build --phase before-mach],
+  "stop-browser" => %w[stop],
   "patch-apply" => %w[misc patch --action apply],
   "write-version" => %w[misc writeVersion],
 }.freeze
@@ -139,7 +140,7 @@ PAGE = <<~HTML
   </main>
   <script>
     const TOKEN = new URLSearchParams(location.search).get("t") || "";
-    const NAMES = { "dev": "dev", "stage": "stage", "before-mach": "build (before-mach)",
+    const NAMES = { "dev": "dev", "stage": "stage", "before-mach": "build (before-mach)", "stop-browser": "開発用を閉じる",
                     "patch-apply": "patch apply", "write-version": "writeVersion" };
     const buttons = document.getElementById("buttons");
     const log = document.getElementById("log");

--- a/tools/launcher.rb
+++ b/tools/launcher.rb
@@ -11,6 +11,8 @@ require "json"
 require "rbconfig"
 require "socket"
 
+require_relative "lib/dev_browser"
+
 ROOT = File.expand_path("..", __dir__)
 FELES = File.join(ROOT, "tools", "feles-build.rb")
 
@@ -36,8 +38,10 @@ module Runner
 
   class << self
     def state(from)
+      browsers = open_browsers # ps を叩くので、mutex を持つ前に
       @mutex.synchronize do
-        from = @dropped if from < @dropped
+        # 持っている範囲の外を訊かれたら頭から返す(新しい run の始まりはこれで分かる)
+        from = @dropped if from < @dropped || from > @dropped + @lines.length
         {
           running: !@pid.nil?,
           name: @name,
@@ -45,8 +49,18 @@ module Runner
           from: from,
           next: @dropped + @lines.length,
           lines: @lines[(from - @dropped)..] || [],
+          open_browsers: browsers,
         }
       end
+    end
+
+    # すでに開いている dev の browser の数。ps は毎回叩くと重いので 2 秒だけ覚えておく。
+    def open_browsers
+      if @browsers_at.nil? || Time.now - @browsers_at > 2
+        @browsers = FelesBuild::DevBrowser.running.length
+        @browsers_at = Time.now
+      end
+      @browsers
     end
 
     def start(name)
@@ -101,79 +115,175 @@ module Runner
   end
 end
 
-PAGE = <<~HTML
+PAGE = <<~'HTML'
   <!doctype html><html lang="ja"><meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>noraneko dev</title>
+  <title>Noraneko を動かす</title>
   <style>
-    :root { color-scheme: light dark; --bg:#fbfaf8; --fg:#2c2a28; --line:#e2ddd6; --soft:#7a736c;
-            --ok:#2f7a43; --warn:#9a6b12; --err:#a33a30; --info:#3a6ea5; }
+    :root { color-scheme: light dark; --bg:#fbfaf8; --fg:#2c2a28; --line:#e2ddd6; --soft:#78716a;
+            --accent:#3a6ea5; --ok:#2f7a43; --warn:#9a6b12; --err:#a33a30; --card:#ffffff; }
     @media (prefers-color-scheme: dark) {
-      :root { --bg:#1c1b1a; --fg:#ddd8d2; --line:#34312e; --soft:#918a83;
-              --ok:#7fc08e; --warn:#d6ad5c; --err:#e08a80; --info:#87b3dd; }
+      :root { --bg:#1c1b1a; --fg:#ddd8d2; --line:#34312e; --soft:#948d86;
+              --accent:#87b3dd; --ok:#7fc08e; --warn:#d6ad5c; --err:#e08a80; --card:#232120; }
     }
     * { box-sizing: border-box; }
-    body { margin:0; background:var(--bg); color:var(--fg); font:14px/1.6 system-ui, sans-serif; }
-    main { max-width: 60rem; margin: 0 auto; padding: 1.5rem 1.25rem 0; }
-    h1 { font-size: 1rem; font-weight: 600; margin: 0 0 1rem; color: var(--soft); }
-    .row { display:flex; flex-wrap:wrap; gap:.5rem; margin-bottom:1rem; }
-    button { font: inherit; padding:.4rem .9rem; border:1px solid var(--line); border-radius:.4rem;
-             background:transparent; color:var(--fg); cursor:pointer; }
-    button:hover:not(:disabled) { border-color: var(--soft); }
-    button:disabled { opacity:.4; cursor:default; }
-    button.stop { margin-left:auto; }
-    #status { display:flex; align-items:center; gap:.5rem; color:var(--soft);
-              padding-bottom:.75rem; border-bottom:1px solid var(--line); }
-    .dot { width:.5rem; height:.5rem; border-radius:50%; background:var(--soft); }
-    .dot.on { background: var(--ok); }
-    #log { font:12px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space:pre-wrap;
-           word-break:break-word; overflow-y:auto; height:60vh; padding:.75rem 0 2rem; }
-    .SUCCESS { color: var(--ok); } .WARN { color: var(--warn); }
-    .ERROR { color: var(--err); } .INFO { color: var(--info); }
-    .end { color: var(--soft); }
+    body { margin:0; background:var(--bg); color:var(--fg);
+           font:15px/1.7 system-ui, -apple-system, "Hiragino Sans", sans-serif; }
+    main { max-width: 44rem; margin:0 auto; padding: 2rem 1.25rem 4rem; }
+    h1 { font-size:1.15rem; font-weight:600; margin:0 0 .25rem; }
+    .lede { color:var(--soft); margin:0 0 1.75rem; font-size:.9rem; }
+
+    .notice { display:flex; gap:.75rem; align-items:flex-start; background:var(--card);
+              border:1px solid var(--line); border-left:3px solid var(--warn);
+              border-radius:.5rem; padding:.85rem 1rem; margin-bottom:1.25rem; }
+    .notice p { margin:0; font-size:.875rem; }
+    .notice .t { font-weight:600; display:block; margin-bottom:.15rem; }
+    .notice button { flex:none; }
+    [hidden] { display:none !important; }
+
+    .choices { display:grid; gap:.75rem; margin-bottom:1.5rem; }
+    .choice { display:flex; align-items:center; gap:1rem; width:100%; text-align:left;
+              background:var(--card); border:1px solid var(--line); border-radius:.6rem;
+              padding:.9rem 1.1rem; color:inherit; font:inherit; cursor:pointer; }
+    .choice:hover:not(:disabled) { border-color:var(--accent); }
+    .choice:disabled { opacity:.45; cursor:default; }
+    .choice b { display:block; font-weight:600; font-size:.95rem; }
+    .choice span { display:block; color:var(--soft); font-size:.8rem; line-height:1.5; }
+
+    button { font:inherit; color:inherit; }
+    .small { padding:.35rem .8rem; border:1px solid var(--line); border-radius:.4rem;
+             background:transparent; cursor:pointer; font-size:.825rem; }
+    .small:hover:not(:disabled) { border-color:var(--soft); }
+    .small:disabled { opacity:.4; cursor:default; }
+
+    #now { background:var(--card); border:1px solid var(--line); border-radius:.6rem;
+           padding:1rem 1.1rem; margin-bottom:1rem; }
+    #nowHead { display:flex; align-items:center; gap:.6rem; }
+    .dot { width:.5rem; height:.5rem; border-radius:50%; background:var(--soft); flex:none; }
+    .dot.on { background:var(--ok); animation: pulse 1.6s ease-in-out infinite; }
+    .dot.bad { background:var(--err); }
+    @keyframes pulse { 50% { opacity:.35; } }
+    #phase { font-weight:600; font-size:.95rem; }
+    #elapsed { color:var(--soft); font-size:.8rem; margin-left:auto; }
+    #hint { color:var(--soft); font-size:.825rem; margin:.4rem 0 0; }
+    #hint.bad { color:var(--err); }
+    #nowActions { margin-top:.85rem; }
+
+    details { border-top:1px solid var(--line); padding-top:1rem; margin-top:1.5rem; }
+    summary { cursor:pointer; color:var(--soft); font-size:.85rem; }
+    summary::marker { color:var(--line); }
+    #log { font:11.5px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; white-space:pre-wrap;
+           word-break:break-word; overflow-y:auto; max-height:26rem; margin-top:.75rem;
+           padding:.75rem .9rem; background:var(--card); border:1px solid var(--line);
+           border-radius:.4rem; color:var(--soft); }
+    #log .SUCCESS { color:var(--ok); } #log .WARN { color:var(--warn); }
+    #log .ERROR { color:var(--err); } #log .INFO { color:var(--fg); }
+    .devrow { display:flex; flex-wrap:wrap; gap:.5rem; margin-top:.75rem; }
   </style>
+
   <main>
-    <h1>noraneko dev</h1>
-    <div class="row" id="buttons"></div>
-    <div id="status"><span class="dot"></span><span id="statusText">止まっている</span></div>
-    <div id="log"></div>
+    <h1>Noraneko を動かす</h1>
+    <p class="lede">この画面から、手元の Noraneko を組み立てて開けます。
+      コマンドを覚えていなくて大丈夫です。</p>
+
+    <div class="notice" id="openNotice" hidden>
+      <p><span class="t">すでに Noraneko が開いています</span>
+         このまま起動しても、新しく組み立てたものは今開いている窓のほうに渡されて、
+         画面には映りません。先に閉じてください。</p>
+      <button class="small" id="closeOpen">閉じる</button>
+    </div>
+
+    <div class="choices" id="choices">
+      <button class="choice" data-cmd="dev">
+        <div><b>起動する</b>
+        <span>手元のコードで組み立てて、Noraneko を開きます。ふだんはこれです。</span></div>
+      </button>
+      <button class="choice" data-cmd="stage">
+        <div><b>配るときと同じ形で起動する</b>
+        <span>人に配るときと同じ組み立てかたで開きます。少し時間がかかります。</span></div>
+      </button>
+    </div>
+
+    <div id="now">
+      <div id="nowHead">
+        <span class="dot" id="dot"></span>
+        <span id="phase">まだ何も動いていません</span>
+        <span id="elapsed"></span>
+      </div>
+      <p id="hint">上のどちらかを押すと始まります。</p>
+      <div id="nowActions"><button class="small" id="stop" disabled>中止する</button></div>
+    </div>
+
+    <details>
+      <summary>くわしい記録</summary>
+      <div id="log"></div>
+      <div class="devrow">
+        <button class="small" data-cmd="stop-browser">開いている Noraneko を閉じる</button>
+        <button class="small" data-cmd="patch-apply">patch を当て直す</button>
+        <button class="small" data-cmd="before-mach">配布用に組み立てる</button>
+        <button class="small" data-cmd="write-version">版の番号を書く</button>
+      </div>
+    </details>
   </main>
+
   <script>
     const TOKEN = new URLSearchParams(location.search).get("t") || "";
-    const NAMES = { "dev": "dev", "stage": "stage", "before-mach": "build (before-mach)", "stop-browser": "開発用を閉じる",
-                    "patch-apply": "patch apply", "write-version": "writeVersion" };
-    const buttons = document.getElementById("buttons");
-    const log = document.getElementById("log");
-    const statusText = document.getElementById("statusText");
-    const dot = document.querySelector(".dot");
-    let from = 0, running = false;
+    const el = (id) => document.getElementById(id);
+    const log = el("log"), dot = el("dot"), phase = el("phase"), hint = el("hint");
 
-    for (const [key, label] of Object.entries(NAMES)) {
-      const b = document.createElement("button");
-      b.textContent = label;
-      b.dataset.cmd = key;
-      b.onclick = () => post("/run?t=" + TOKEN + "&cmd=" + key);
-      buttons.append(b);
+    // log の一行を、いま何をしているかの言葉にする。上から順に、最初に当たったもの。
+    const PHASES = [
+      [/Downloading binary|not found\. Downloading/, "Noraneko 本体をダウンロードしています",
+       "はじめての起動では数分かかります。そのままお待ちください。"],
+      [/\[initializer\]|\[omni\]/, "下ごしらえをしています", "Noraneko 本体を用意しています。"],
+      [/\[patcher\]/, "手を入れています", ""],
+      [/\[builder\]/, "組み立てています", "いちばん時間のかかるところです。1〜2 分ほど。"],
+      [/\[injector\]|\[xhtml\]/, "組み込んでいます", ""],
+      [/\[dev-env\]|\[dev-server\]/, "準備をしています", "もうすぐ開きます。"],
+      [/Launching browser/, "Noraneko を開いています", "窓が出てこないときは、下の記録を見てください。"],
+      [/Browser Closed/, "閉じられました", ""],
+    ];
+    const DONE = {
+      dev: ["終わりました", "Noraneko の窓を閉じたので、ここも終わりました。"],
+      stage: ["終わりました", "Noraneko の窓を閉じたので、ここも終わりました。"],
+      "stop-browser": ["閉じました", "開いていた Noraneko を閉じました。"],
+    };
+
+    let from = 0, phaseText = null, phaseHint = "", failed = false, lastError = "";
+
+    for (const b of document.querySelectorAll("[data-cmd]")) {
+      b.onclick = () => post("/run?t=" + TOKEN + "&cmd=" + b.dataset.cmd);
     }
-    const stop = document.createElement("button");
-    stop.textContent = "止める";
-    stop.className = "stop";
-    stop.onclick = () => post("/stop?t=" + TOKEN);
-    buttons.append(stop);
+    el("stop").onclick = () => post("/stop?t=" + TOKEN);
+    el("closeOpen").onclick = () => post("/run?t=" + TOKEN + "&cmd=stop-browser");
 
-    async function post(url) { await fetch(url, { method: "POST" }); tick(); }
+    async function post(url) {
+      try { await fetch(url, { method: "POST" }); } catch {}
+      tick();
+    }
 
     function elapsed(s) {
-      if (s === null) return "";
-      return s < 60 ? s + "秒" : Math.floor(s / 60) + "分" + String(s % 60).padStart(2, "0") + "秒";
+      if (s === null || s === undefined) return "";
+      return s < 60 ? s + " 秒" : Math.floor(s / 60) + " 分 " + (s % 60) + " 秒";
+    }
+
+    function read(line) {
+      const level = line.match(/^\[[^\]]+\] (INFO|WARN|ERROR|SUCCESS):/);
+      if (level && level[1] === "ERROR") { lastError = line; }
+      const done = line.match(/^--- 終わりました \((.+)\) ---$/);
+      if (done) { failed = !/^exit 0$/.test(done[1]); return; }
+      for (const [re, text, tip] of PHASES) {
+        if (re.test(line)) { phaseText = text; phaseHint = tip; return; }
+      }
     }
 
     function append(lines) {
       const atBottom = log.scrollTop + log.clientHeight >= log.scrollHeight - 40;
       for (const line of lines) {
+        read(line);
+        const level = line.match(/^\[[^\]]+\] (INFO|WARN|ERROR|SUCCESS):/);
         const div = document.createElement("div");
-        const level = line.match(/^\\[[^\\]]+\\] (INFO|WARN|ERROR|SUCCESS):/);
-        div.className = level ? level[1] : (line.startsWith("---") ? "end" : "");
+        div.className = level ? level[1] : "";
         div.textContent = line;
         log.append(div);
       }
@@ -183,18 +293,38 @@ PAGE = <<~HTML
     async function tick() {
       let s;
       try { s = await (await fetch("/state?t=" + TOKEN + "&from=" + from)).json(); } catch { return; }
-      if (s.from !== from) { log.textContent = ""; }
+      if (s.from !== from) {
+        log.textContent = "";
+        phaseText = null; phaseHint = ""; failed = false; lastError = "";
+      }
       from = s.next;
       append(s.lines);
-      running = s.running;
-      dot.classList.toggle("on", running);
-      statusText.textContent = running
-        ? "走っている (" + NAMES[s.name] + ", " + elapsed(s.seconds) + ")"
-        : "止まっている";
-      for (const b of buttons.children) {
-        b.disabled = b.className === "stop" ? !running : running;
+
+      el("openNotice").hidden = !(s.open_browsers > 0) || s.running;
+      dot.className = "dot" + (s.running ? " on" : (failed ? " bad" : ""));
+      el("elapsed").textContent = s.running ? elapsed(s.seconds) : "";
+      el("stop").disabled = !s.running;
+      for (const b of document.querySelectorAll("[data-cmd]")) b.disabled = s.running;
+
+      if (s.running) {
+        phase.textContent = phaseText || "はじめています";
+        hint.textContent = phaseHint;
+        hint.className = "";
+      } else if (failed) {
+        phase.textContent = "うまくいきませんでした";
+        hint.textContent = lastError
+          ? "理由: " + lastError.replace(/^\[[^\]]+\] ERROR: /, "")
+          : "「くわしい記録」の赤い行に理由が出ています。";
+        hint.className = "bad";
+      } else if (log.childElementCount) {
+        const done = DONE[phaseLast] || ["終わりました", ""];
+        phase.textContent = done[0];
+        hint.textContent = done[1];
+        hint.className = "";
       }
+      if (s.name) phaseLast = s.name;
     }
+    let phaseLast = null;
     tick();
     setInterval(tick, 700);
   </script>

--- a/tools/launcher.rb
+++ b/tools/launcher.rb
@@ -1,0 +1,250 @@
+#!/usr/bin/env ruby
+# SPDX-License-Identifier: MPL-2.0
+#
+#   ruby tools/launcher.rb        (= deno task launcher)
+#
+# feles-build を押して呼ぶための小さな画面。127.0.0.1 にだけ立って、ブラウザが開く。
+# 走らせられるのは下の COMMANDS に書いてあるものだけ。gem は使わない。
+
+require "cgi"
+require "json"
+require "rbconfig"
+require "socket"
+
+ROOT = File.expand_path("..", __dir__)
+FELES = File.join(ROOT, "tools", "feles-build.rb")
+
+# 押せるもの。ここに無い文字列は走らない(外から叩かれても、この表の外には出ない)
+COMMANDS = {
+  "dev" => %w[dev],
+  "stage" => %w[stage],
+  "before-mach" => %w[build --phase before-mach],
+  "patch-apply" => %w[misc patch --action apply],
+  "write-version" => %w[misc writeVersion],
+}.freeze
+
+# 走っているものは、いつも一つ。log は後ろ 2000 行だけ覚えておく。
+module Runner
+  KEEP = 2000
+  @mutex = Mutex.new
+  @lines = []
+  @dropped = 0 # 捨てた行数。画面が「どこまで見たか」を数えるのに要る
+  @pid = nil
+  @name = nil
+  @started_at = nil
+
+  class << self
+    def state(from)
+      @mutex.synchronize do
+        from = @dropped if from < @dropped
+        {
+          running: !@pid.nil?,
+          name: @name,
+          seconds: @started_at ? (Time.now - @started_at).to_i : nil,
+          from: from,
+          next: @dropped + @lines.length,
+          lines: @lines[(from - @dropped)..] || [],
+        }
+      end
+    end
+
+    def start(name)
+      args = COMMANDS[name] or return "そんな command は無い: #{name}"
+      @mutex.synchronize do
+        return "もう #{@name} が走っている" if @pid
+
+        reader, writer = IO.pipe
+        # pgroup: true で、止めるときに vite や browser も一緒に畳める
+        pid = spawn(RbConfig.ruby, FELES, *args,
+                    chdir: ROOT, in: File::NULL, out: writer, err: %i[child out], pgroup: true)
+        writer.close
+        @pid = pid
+        @name = name
+        @started_at = Time.now
+        @lines = []
+        @dropped = 0
+        Thread.new { pump(reader, pid) }
+      end
+      nil
+    end
+
+    def stop
+      @mutex.synchronize do
+        return "走っていない" unless @pid
+
+        Process.kill("TERM", -@pid) rescue nil
+      end
+      nil
+    end
+
+    private
+
+    def pump(reader, pid)
+      reader.each_line { |line| push(line.chomp) }
+      reader.close
+      status = (Process.wait2(pid)[1] rescue nil)
+      how = if status.nil? then "?"
+            elsif status.signaled? then "SIG#{Signal.signame(status.termsig)}"
+            else "exit #{status.exitstatus}"
+            end
+      push("--- 終わりました (#{how}) ---")
+      @mutex.synchronize { @pid = @name = @started_at = nil if @pid == pid }
+    end
+
+    def push(line)
+      @mutex.synchronize do
+        @lines << line.gsub(/\e\[[0-9;]*m/, "") # 色は画面側で塗る
+        @dropped += @lines.shift(@lines.length - KEEP).length if @lines.length > KEEP
+      end
+    end
+  end
+end
+
+PAGE = <<~HTML
+  <!doctype html><html lang="ja"><meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>noraneko dev</title>
+  <style>
+    :root { color-scheme: light dark; --bg:#fbfaf8; --fg:#2c2a28; --line:#e2ddd6; --soft:#7a736c;
+            --ok:#2f7a43; --warn:#9a6b12; --err:#a33a30; --info:#3a6ea5; }
+    @media (prefers-color-scheme: dark) {
+      :root { --bg:#1c1b1a; --fg:#ddd8d2; --line:#34312e; --soft:#918a83;
+              --ok:#7fc08e; --warn:#d6ad5c; --err:#e08a80; --info:#87b3dd; }
+    }
+    * { box-sizing: border-box; }
+    body { margin:0; background:var(--bg); color:var(--fg); font:14px/1.6 system-ui, sans-serif; }
+    main { max-width: 60rem; margin: 0 auto; padding: 1.5rem 1.25rem 0; }
+    h1 { font-size: 1rem; font-weight: 600; margin: 0 0 1rem; color: var(--soft); }
+    .row { display:flex; flex-wrap:wrap; gap:.5rem; margin-bottom:1rem; }
+    button { font: inherit; padding:.4rem .9rem; border:1px solid var(--line); border-radius:.4rem;
+             background:transparent; color:var(--fg); cursor:pointer; }
+    button:hover:not(:disabled) { border-color: var(--soft); }
+    button:disabled { opacity:.4; cursor:default; }
+    button.stop { margin-left:auto; }
+    #status { display:flex; align-items:center; gap:.5rem; color:var(--soft);
+              padding-bottom:.75rem; border-bottom:1px solid var(--line); }
+    .dot { width:.5rem; height:.5rem; border-radius:50%; background:var(--soft); }
+    .dot.on { background: var(--ok); }
+    #log { font:12px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space:pre-wrap;
+           word-break:break-word; overflow-y:auto; height:60vh; padding:.75rem 0 2rem; }
+    .SUCCESS { color: var(--ok); } .WARN { color: var(--warn); }
+    .ERROR { color: var(--err); } .INFO { color: var(--info); }
+    .end { color: var(--soft); }
+  </style>
+  <main>
+    <h1>noraneko dev</h1>
+    <div class="row" id="buttons"></div>
+    <div id="status"><span class="dot"></span><span id="statusText">止まっている</span></div>
+    <div id="log"></div>
+  </main>
+  <script>
+    const TOKEN = new URLSearchParams(location.search).get("t") || "";
+    const NAMES = { "dev": "dev", "stage": "stage", "before-mach": "build (before-mach)",
+                    "patch-apply": "patch apply", "write-version": "writeVersion" };
+    const buttons = document.getElementById("buttons");
+    const log = document.getElementById("log");
+    const statusText = document.getElementById("statusText");
+    const dot = document.querySelector(".dot");
+    let from = 0, running = false;
+
+    for (const [key, label] of Object.entries(NAMES)) {
+      const b = document.createElement("button");
+      b.textContent = label;
+      b.dataset.cmd = key;
+      b.onclick = () => post("/run?t=" + TOKEN + "&cmd=" + key);
+      buttons.append(b);
+    }
+    const stop = document.createElement("button");
+    stop.textContent = "止める";
+    stop.className = "stop";
+    stop.onclick = () => post("/stop?t=" + TOKEN);
+    buttons.append(stop);
+
+    async function post(url) { await fetch(url, { method: "POST" }); tick(); }
+
+    function elapsed(s) {
+      if (s === null) return "";
+      return s < 60 ? s + "秒" : Math.floor(s / 60) + "分" + String(s % 60).padStart(2, "0") + "秒";
+    }
+
+    function append(lines) {
+      const atBottom = log.scrollTop + log.clientHeight >= log.scrollHeight - 40;
+      for (const line of lines) {
+        const div = document.createElement("div");
+        const level = line.match(/^\\[[^\\]]+\\] (INFO|WARN|ERROR|SUCCESS):/);
+        div.className = level ? level[1] : (line.startsWith("---") ? "end" : "");
+        div.textContent = line;
+        log.append(div);
+      }
+      if (atBottom) log.scrollTop = log.scrollHeight;
+    }
+
+    async function tick() {
+      let s;
+      try { s = await (await fetch("/state?t=" + TOKEN + "&from=" + from)).json(); } catch { return; }
+      if (s.from !== from) { log.textContent = ""; }
+      from = s.next;
+      append(s.lines);
+      running = s.running;
+      dot.classList.toggle("on", running);
+      statusText.textContent = running
+        ? "走っている (" + NAMES[s.name] + ", " + elapsed(s.seconds) + ")"
+        : "止まっている";
+      for (const b of buttons.children) {
+        b.disabled = b.className === "stop" ? !running : running;
+      }
+    }
+    tick();
+    setInterval(tick, 700);
+  </script>
+HTML
+
+def respond(socket, status, type, body)
+  socket.print "HTTP/1.1 #{status}\r\nContent-Type: #{type}\r\n" \
+               "Content-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}"
+end
+
+def handle(socket, token)
+  request = socket.gets or return
+  method, target, = request.split
+  nil while (header = socket.gets) && header.strip != "" # header は読み捨てる
+
+  path, _, query = target.to_s.partition("?")
+  params = CGI.parse(query)
+  given = params["t"]&.first
+
+  return respond(socket, "200 OK", "text/html; charset=utf-8", PAGE) if path == "/" && method == "GET"
+  # 画面以外は token を見る(他所のページから叩かれて build が始まらないように)
+  return respond(socket, "403 Forbidden", "text/plain", "no") unless given == token
+
+  case [method, path]
+  in ["GET", "/state"]
+    respond(socket, "200 OK", "application/json", JSON.generate(Runner.state(params["from"]&.first.to_i)))
+  in ["POST", "/run"]
+    error = Runner.start(params["cmd"]&.first.to_s)
+    respond(socket, error ? "409 Conflict" : "200 OK", "text/plain", error || "ok")
+  in ["POST", "/stop"]
+    error = Runner.stop
+    respond(socket, "200 OK", "text/plain", error || "ok")
+  else
+    respond(socket, "404 Not Found", "text/plain", "no")
+  end
+rescue => e
+  warn "launcher: #{e.message}"
+ensure
+  socket.close rescue nil
+end
+
+server = TCPServer.new("127.0.0.1", (ENV["PORT"] || 0).to_i) # 0 = 空いている port を借りる
+token = format("%08x%08x", rand(2**32), rand(2**32))
+url = "http://127.0.0.1:#{server.addr[1]}/?t=#{token}"
+
+puts "noraneko dev launcher: #{url}"
+system("open", url) if RUBY_PLATFORM.include?("darwin")
+
+Signal.trap("INT") do
+  Runner.stop
+  exit 0
+end
+
+loop { Thread.new(server.accept) { |socket| handle(socket, token) } }

--- a/tools/lib/browser_launcher.rb
+++ b/tools/lib/browser_launcher.rb
@@ -2,11 +2,14 @@
 
 require "fileutils"
 require_relative "defines"
+require_relative "dev_browser"
 require_relative "utils"
 
 module FelesBuild
   # browser を起こして、閉じるまで出るものを読む。
   module BrowserLauncher
+    LOGGER = Utils::Logger.new("launcher")
+
     # Firefox の出力は色で読む(上から順に、当たったものの色)
     COLORS = {
       /MOZ_CRASH|JavaScript error:|console\.error|\] Errors|\[fluent\] (Couldn't find a message:|Missing)|EGL Error:/ => 31,
@@ -28,6 +31,14 @@ module FelesBuild
       # 素の Firefox には buildid2 の patch が無く、build が変わっても startup cache が
       # 古いまま残る(chrome registry がずれる)。開く前に捨てて読み直させる。
       FileUtils.rm_rf(File.join(Defines::PATHS[:profile_test], "startupCache")) if Defines::STOCK_FIREFOX
+
+      # 同じ profile の先客が居ると、Firefox はそちらに渡して、こちらはすぐ終わる。
+      # 黙って渡すと「起きてすぐ閉じた」ように見えるので、先に言う。
+      DevBrowser.running.each do |pid, _|
+        LOGGER.warn "すでに開発用の noraneko が動いている (pid #{pid})。"
+        LOGGER.warn "この profile は先客に渡るので、いま建てたものは映らない。"
+        LOGGER.warn "閉じてから起こすなら: deno task feles-build stop"
+      end
 
       cmd = command(port)
       puts "[launcher] Launching browser with command: #{cmd.join(' ')}"

--- a/tools/lib/dev_browser.rb
+++ b/tools/lib/dev_browser.rb
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MPL-2.0
+
+require_relative "defines"
+require_relative "utils"
+
+module FelesBuild
+  # 手元の dev で起きている noraneko を閉じる。
+  #
+  # ここは人の使っているブラウザを落としかねない場所なので、「閉じてよいもの」を
+  # 狭いほうから決める。二つの錠を**両方**通ったものだけを閉じる:
+  #
+  #   1. 実行ファイルが、この repo の _dist/bin/ の中にある
+  #   2. --profile が、この repo の _dist/profile/test を指している
+  #
+  # どちらも、この repo の PROJECT_ROOT から組み立てた絶対 path との前方一致で見る。
+  # 配って入れてもらった Noraneko(/Applications/… や ~/… から起きて、自分の profile を
+  # 使っているもの)は、repo の外に居るのでどちらの錠も通らない。
+  # 錠は and で、片方だけでは開かない。試験は tools/test/dev_browser_test.rb。
+  module DevBrowser
+    LOGGER = Utils::Logger.new("dev-browser")
+
+    EXE_PREFIX = File.join(Defines::PATHS[:bin_root], "")       # .../_dist/bin/
+    PROFILE = Defines::PATHS[:profile_test]                     # .../_dist/profile/test
+
+    # 閉じてよいものか。command 一行だけを見る、副作用の無い判定(試験はここを突く)。
+    def self.ours?(command, exe_prefix: EXE_PREFIX, profile: PROFILE)
+      return false if command.nil? || command.empty?
+      return false unless command.start_with?(exe_prefix)
+
+      # `--profile <path>` の <path> がちょうどその profile であること
+      command.match?(/(?<=\s)--profile\s+#{Regexp.escape(profile)}(?=\s|\z)/)
+    end
+
+    # [pid, command] の一覧。親だけ(子の plugin-container は親を閉じれば一緒に畳まれる)。
+    def self.running
+      `ps -axo pid=,command= 2>/dev/null`.lines.filter_map do |line|
+        pid, _, command = line.strip.partition(" ")
+        next unless ours?(command)
+        # 子プロセス(-parentPid を持つもの)は数えない
+        next if command.include?("-parentPid")
+
+        [pid.to_i, command]
+      end
+    end
+
+    def self.stop
+      found = running
+      if found.empty?
+        LOGGER.info "開発用の noraneko は動いていない。"
+        return
+      end
+
+      found.each do |pid, command|
+        LOGGER.info "閉じる: pid #{pid}"
+        LOGGER.info "        #{command[0, 120]}"
+        Process.kill("TERM", pid) rescue nil
+      end
+
+      # 畳むのを少し待つ。閉じきらないものだけ、あらためて落とす。
+      20.times do
+        break if running.empty?
+
+        sleep 0.25
+      end
+      left = running
+      left.each do |pid, _|
+        LOGGER.warn "TERM で閉じなかったので KILL する: pid #{pid}"
+        Process.kill("KILL", pid) rescue nil
+      end
+
+      LOGGER.success "#{found.length} 個 閉じた。"
+    end
+  end
+end

--- a/tools/test/dev_browser_test.rb
+++ b/tools/test/dev_browser_test.rb
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+#   ruby tools/test/dev_browser_test.rb   (= deno task test:tools)
+#
+# DevBrowser.ours? が、配った Noraneko を決して掴まないことを確かめる。
+# ここが緩むと人の使っているブラウザが落ちるので、緩めるときは必ずここに一本足すこと。
+
+require "minitest/autorun"
+require_relative "../lib/dev_browser"
+
+class DevBrowserTest < Minitest::Test
+  BIN = "/home/someone/repos/noraneko/_dist/bin/"
+  PROFILE = "/home/someone/repos/noraneko/_dist/profile/test"
+
+  def ours?(command) = FelesBuild::DevBrowser.ours?(command, exe_prefix: BIN, profile: PROFILE)
+
+  def dev_command(exe: "#{BIN}noraneko/Noraneko.app/Contents/MacOS/noraneko", profile: PROFILE)
+    "#{exe} --profile #{profile} --remote-debugging-port 5180 --wait-for-browser --jsdebugger"
+  end
+
+  def test_手元の_dev_は_掴む
+    assert ours?(dev_command)
+  end
+
+  def test_linux_の_flat_配置の_dev_も_掴む
+    assert ours?(dev_command(exe: "#{BIN}noraneko/noraneko-bin"))
+  end
+
+  # ここから下が本題。どれも掴んではいけない。
+  def test_配った_Noraneko_は_掴まない
+    refute ours?("/Applications/Noraneko.app/Contents/MacOS/noraneko")
+    refute ours?("/Applications/Noraneko.app/Contents/MacOS/noraneko --profile /Users/x/Library/Application Support/Noraneko/Profiles/abc.default")
+    refute ours?("/usr/lib/noraneko/noraneko-bin")
+    refute ours?("/opt/noraneko/noraneko")
+  end
+
+  def test_素の_Firefox_も_掴まない
+    refute ours?("/Applications/Firefox.app/Contents/MacOS/firefox")
+  end
+
+  def test_repo_の_中から起きていても_別の_profile_なら掴まない
+    refute ours?(dev_command(profile: "/Users/x/Library/Application Support/Noraneko/Profiles/abc.default"))
+    refute ours?(dev_command(profile: "#{PROFILE}-backup"))  # 前方一致だけで通らないこと
+    refute ours?("#{BIN}noraneko/Noraneko.app/Contents/MacOS/noraneko")  # --profile が無い
+  end
+
+  def test_dev_の_profile_でも_repo_の外の実行ファイルなら掴まない
+    refute ours?("/Applications/Noraneko.app/Contents/MacOS/noraneko --profile #{PROFILE}")
+  end
+
+  def test_名前が似ているだけの_path_は掴まない
+    refute ours?("/home/someone/repos/noraneko/_dist/bin-old/noraneko --profile #{PROFILE}")
+    refute ours?("/home/someone/repos/noraneko-fork/_dist/bin/noraneko --profile #{PROFILE}")
+  end
+
+  def test_空やゴミ
+    refute ours?(nil)
+    refute ours?("")
+    refute ours?("--profile #{PROFILE}")
+  end
+end


### PR DESCRIPTION
#204 の上に積んでいます(base が `shiro/scripts-in-ruby`)。先にそちらを見てください。

手元で Noraneko を動かすための、小さな画面です。`deno task launcher` で 127.0.0.1 に立って、
ブラウザが開きます。Ruby の stdlib だけ(TCPServer に直に喋る、250 行)。gem も npm も増えません。

## 三つ入っています

**1. ランチャー(`tools/launcher.rb`)**

表に出るボタンは二つだけにしました。「起動する」と「配るときと同じ形で起動する」。
それぞれに何が起きるかを一行そえてあります。`before-mach` や `patch apply` のような
開発者向けの操作は「くわしい記録」の中に畳んであります。

走っているあいだは、log をそのまま見せるのではなく「いま何をしているか」に訳します
(「組み立てています / いちばん時間のかかるところです。1〜2 分ほど」)。
初回の runtime ダウンロードには「はじめての起動では数分かかります」を添えます。
無言で数分かかるのが、たぶんいちばん不安なところなので。

失敗したときは「うまくいきませんでした」と理由の行をそのまま出します。
記録を開いて赤い行を探さなくていいように。

**2. 開発用の Noraneko を閉じる(`tools/lib/dev_browser.rb`、`feles-build stop`)**

Firefox は profile を先に握っているほうへ渡すので、前の session の dev browser が残っていると、
次の `dev` は起きた瞬間に先客へ渡して黙って終わります。建て直したものが映らないのに、
log は「起きて閉じた」としか言いません。これに一度はまったので、閉じる口を作りました。

**3. その罠を、先に知らせる**

`dev` のときに先客が居たら warn を出します(閉じはしません。勝手に人の窓を閉じないので)。
ランチャーでは上に知らせと「閉じる」ボタンが出ます。

## 「配ったものは切らない」をどう作ったか

ここは間違えると人の使っているブラウザを落とす場所なので、**閉じてよいものを狭いほうから**
決めています。二つの錠を**両方**通ったものだけ:

1. 実行ファイルが、この checkout の `_dist/bin/` の中にある
2. `--profile` が、この checkout の `_dist/profile/test` ちょうどである

どちらも `PROJECT_ROOT` から組み立てた絶対 path なので、配って入れてもらった Noraneko
(checkout の外に居て、その人自身の profile を使う)はどちらの錠も通りません。

二つ目は飾りではありません。手元で実際にこうなりました:

    掴まない  /Applications/Firefox.app/.../firefox
    掴まない  .../_dist/bin/noraneko/Noraneko.app/.../noraneko   ← 同じ binary、別の profile
    掴む      .../_dist/bin/noraneko/Noraneko.app/.../noraneko   ← dev の profile
    掴まない  .../_dist/bin/... (Browser Toolbox、別の profile)

同じ checkout の binary から起きている三つのうち、掴むのは一つだけです。

`tools/test/dev_browser_test.rb` に 8 本(`deno task test:tools`)。`/Applications` のもの、
ユーザの profile を使っているもの、`_dist/profile/test-backup` のような前方一致だけのもの、
`noraneko-fork` のような似た名前、`--profile` の無いもの — 全部「掴まない」を押さえています。
**緩めるときは必ずここに一本足してください**、とファイルの頭にも書いてあります。

## 確かめたこと / まだのこと

- 判定のほうは、いま動いている 11 プロセスに対して一つずつ確かめました(上の表)。
- ランチャーは token 無しで弾かれること(403)、表に無い command が通らないこと、
  走らせて log が流れること、途中で止めて子が全部消えることを確認しています。
- **実際に落とすところ(TERM → 待つ → 効かなければ KILL)は、まだ本番で走っていません。**
  落とす相手が二日前から開いている実物だったので、勝手にはやりませんでした。
- ランチャーは 127.0.0.1 にだけ立ち、起動ごとの token を画面以外の口で見ます
  (他所のページから localhost を叩かれて build が始まらないように)。
  走らせられるのは `COMMANDS` の表にあるものだけで、任意の command は通りません。

## 落とす場合

ランチャーは無くても困りません(`deno task feles-build` で足ります)。
もし入れるなら **`stop` と `dev_browser.rb` だけ**でも意味があります —
「前の dev が残っていると次の dev が黙って効かない」は、画面が無くても踏む罠なので。

## この PR について

Shiro(Claude Opus 5)が @nyanrus と一緒に書きました。読み違えていたら教えてください。
とくに「非開発者に親切」のことば選びは、わたしの手癖が出ているかもしれません。
