### PR TITLE
まず触れるように ── README の頭に手順を、押して動かす画面に一枚(docs/LAUNCHER.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For developers and contributors, see the following documentation:
 | Document | Description |
 |----------|-------------|
 | [Development](docs/DEV.md) | Getting a dev browser running (macOS arm64 / Linux) |
+| [Launcher](docs/LAUNCHER.md) | A page that builds and opens Noraneko for you, no commands to remember |
 | [Architecture](docs/ARCHITECTURE.md) | High-level architecture overview |
 | [Build System](docs/BUILD_SYSTEM.md) | Build system and tooling documentation |
 | [Event Dispatcher](docs/RPC_SYSTEM_README.md) | Inter-module communication system |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,34 @@ Noraneko Browser is currently testbed for Floorp 12.
 
 Have a nice day!
 
+## Try it
+
+Two commands, on macOS (Apple Silicon) or Linux. Nothing is installed
+system-wide — the Firefox runtime, the profile and the build output all live
+under `_dist/`, and deleting the folder undoes everything.
+
+```sh
+git clone https://github.com/f3liz-casa/noraneko
+cd noraneko
+mise install                              # deno + ruby, pinned in mise.toml
+mise exec -- deno task feles-build dev
+```
+
+The first run downloads a Firefox runtime (~66 MB) and builds the browser, so
+give it a few minutes; after that a Noraneko window opens with hot reload. Close
+the window and everything stops with it.
+
+Would rather not keep commands in your head? `mise exec -- deno task launcher`
+opens a page that does the same from two buttons — see
+**[Launcher](docs/LAUNCHER.md)**.
+
+You need **git**, **[mise](https://mise.jdx.dev)** and ~3 GB of disk; on macOS
+also the Xcode Command Line Tools (`xcode-select --install`), because the
+runtime is ad-hoc signed on extraction. macOS arm64 is verified; Linux aarch64
+should work; x86_64 and Windows have no current runtime published yet.
+**[Development](docs/DEV.md)** has the details, the platform table and what to do
+when something goes wrong.
+
 <p align="center">
 <img src=".github/assets/readme/noraneko.structure.light.excalidraw.svg#gh-light-mode-only" width="1200px" alt="Noraneko Logo and Workmark"></img>
 <img src=".github/assets/readme/noraneko.structure.dark.excalidraw.svg#gh-dark-mode-only" width="1200px" alt="Noraneko Logo and Workmark"></img>
@@ -61,16 +89,6 @@ For developers and contributors, see the following documentation:
 | [Event Dispatcher](docs/RPC_SYSTEM_README.md) | Inter-module communication system |
 | [Shared Code](docs/SHARED_CODE_STRUCTURE.md) | Shared code organization |
 | [Questions](docs/QUESTIONS.md) | Open questions for contributors |
-
-### Quick Start (Development)
-
-```bash
-# Install dependencies
-deno install --allow-scripts
-
-# Run development build with hot reload
-deno task feles-build dev
-```
 
 ## Useful Links
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For developers and contributors, see the following documentation:
 | [Launcher](docs/LAUNCHER.md) | A page that builds and opens Noraneko for you, no commands to remember |
 | [Architecture](docs/ARCHITECTURE.md) | High-level architecture overview |
 | [Build System](docs/BUILD_SYSTEM.md) | Build system and tooling documentation |
-| [Event Dispatcher](docs/RPC_SYSTEM_README.md) | Inter-module communication system |
+| [Actors](browser-features/webext-actors/README.md) | How a feature reaches a page: xpi + JSWindowActor, one file per actor |
 | [Shared Code](docs/SHARED_CODE_STRUCTURE.md) | Shared code organization |
 | [Questions](docs/QUESTIONS.md) | Open questions for contributors |
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -25,6 +25,9 @@ mise install
 mise exec -- deno task feles-build dev
 ```
 
+If you would rather not keep commands in your head, `deno task launcher` opens a
+page that does all of this from two buttons — see [Launcher](LAUNCHER.md).
+
 `mise install` only *installs* the tools — it does not put them on your `PATH`.
 Either keep the `mise exec --` prefix, or activate mise in your shell once
 (`eval "$(mise activate bash)"`, `zsh`, …) and then just
@@ -107,5 +110,6 @@ switch.
 
 ## Next
 
+- [Launcher](LAUNCHER.md) — the same thing from a page, with no commands to remember
 - [Build System](BUILD_SYSTEM.md) — what each step above actually does
 - [Architecture](ARCHITECTURE.md) — how the pieces fit together

--- a/docs/LAUNCHER.md
+++ b/docs/LAUNCHER.md
@@ -1,0 +1,96 @@
+# The launcher
+
+A small page that builds and opens Noraneko for you, so you do not have to
+remember any commands. It runs on your own machine and talks to nothing else.
+
+If you would rather type the commands, [DEV.md](DEV.md) is that route, and it is
+the same work underneath.
+
+## Start it
+
+```sh
+mise exec -- deno task launcher
+```
+
+It prints a URL and, on macOS, opens it for you:
+
+```
+noraneko dev launcher: http://127.0.0.1:53271/?t=662633ed7e6f0952
+```
+
+The port is whatever was free. Set `PORT` if you want a fixed one
+(`PORT=5199 mise exec -- deno task launcher`). Keep the terminal open — that
+process *is* the launcher. `Ctrl-C` stops whatever is running and quits.
+
+The first run still has to download the Firefox runtime (~66 MB) and build
+everything, so it takes a few minutes. The page says so while it waits.
+
+## What you can press
+
+Two buttons, and that is usually all you need:
+
+| Button | What it does |
+|---|---|
+| **起動する** — *Start* | Builds from the code in your checkout and opens Noraneko. The everyday one. (`feles-build dev`) |
+| **配るときと同じ形で起動する** — *Start the way it ships* | Builds the way a release is built, then opens it in a dev browser. Slower. (`feles-build stage`) |
+
+While something is running, the buttons grey out and **中止する** (*Stop*) is
+live. Stopping sends `TERM` to the whole process group, so the Vite servers and
+the browser go down with it rather than being left behind.
+
+Under **くわしい記録** (*The full record*) there is the raw log, plus four
+buttons for the less common jobs:
+
+| Button | Command |
+|---|---|
+| 開いている Noraneko を閉じる — *Close the open Noraneko* | `feles-build stop` |
+| patch を当て直す — *Re-apply patches* | `feles-build misc patch --action apply` |
+| 配布用に組み立てる — *Build for distribution* | `feles-build build --phase before-mach` |
+| 版の番号を書く — *Write the version* | `feles-build misc writeVersion` |
+
+## What it shows you
+
+The line at the top is the build, said in plain words rather than in log lines —
+*downloading Noraneko itself*, *building*, *opening Noraneko* — with how long it
+has been going. The log underneath is there when you want it, colour and all,
+keeping the last 2000 lines.
+
+One notice appears on its own: **すでに Noraneko が開いています** (*A Noraneko is
+already open*). Firefox hands a second launch over to the copy that already owns
+the profile, so the thing you just built would never appear on screen. The
+notice comes with a button that closes the open one. It only counts browsers
+started from this checkout, against this checkout's dev profile — a Noraneko you
+installed normally is not touched.
+
+If a build fails, the dot turns red and the reason is quoted from the log, so
+you do not have to go looking for it.
+
+## What it will not do
+
+It is a build button, not a server, and it is written to stay that way:
+
+- It listens on **127.0.0.1 only**. Nothing on your network can reach it.
+- Every request except the page itself needs the token from the URL, so a page
+  you happen to have open elsewhere cannot start a build behind your back.
+- It can only run the six commands listed above. They are a fixed table in
+  `tools/launcher.rb`; a name that is not in it does not run.
+- It uses no gems — just the Ruby that `mise install` put there.
+
+## When something goes wrong
+
+- **The page does not open** (Linux, or macOS without a default browser) — copy
+  the URL the terminal printed, token and all. Without `?t=…` the buttons will
+  not work.
+- **"すでに Noraneko が開いています" will not go away** — press its button; if it
+  still will not, a browser from an earlier run may have been killed with
+  `kill -9`, which orphans its content processes and leaves the profile lock
+  held. Close them by hand, then try again.
+- **Nothing happens when you press a button** — look at the terminal running the
+  launcher; it prints the reason there.
+- **A build fails** — open くわしい記録 and read the red lines. The same failures
+  and their fixes are listed in [DEV.md](DEV.md#when-something-goes-wrong).
+
+## Next
+
+- [Development](DEV.md) — the same thing as commands, and what each step does
+- [Build System](BUILD_SYSTEM.md) — the steps themselves


### PR DESCRIPTION
「試してみたい」と思った人が、まず手順にたどり着けるようにする二つ。

## 1. README の頭に **Try it**

これまでは Credits と docs の表を越えないと手順が出てきませんでした（しかも中身が古くて、`deno install --allow-scripts` はもう要らない）。冒頭に移して書き直しました。

```sh
git clone https://github.com/f3liz-casa/noraneko
cd noraneko
mise install
mise exec -- deno task feles-build dev
```

一回目は runtime を落とすので数分かかること、窓を閉じれば全部止まること、`_dist/` を消せば元に戻ること。要るもの（git / mise / 3GB / macOS は Xcode CLT）と platform の温度も一段落だけ添えて、細かいところは DEV.md に任せています。下にあった「Quick Start (Development)」は同じことを古い形で言っていたので落としました。

**確かめました**: まっさらな clone（`node_modules` 無し・`deno install` 無し）で `feles-build build --phase before-mach` が通り、七つの workspace が全部建ちます。npm の解決は deno が自分でやります（`nodeModulesDir: "auto"`）。

## 2. `docs/LAUNCHER.md`

`deno task launcher` は #205 で入ったのに、README からも docs からも指されていませんでした。コマンドを覚えたくない人の入り口なので、その人に向けて一枚。

- **押せるもの** ── 上の二つ（起動する / 配るときと同じ形で起動する）と、「くわしい記録」の下の四つ。それぞれ裏で何の command が走るか
- **画面が見せているもの** ── 段を log の行でなく言葉で、経った時間、失敗したら赤い理由。「すでに Noraneko が開いています」が出る理由も（Firefox は二つ目の起動を先客に渡すので、いま建てたものが映らない）。数えているのはこの checkout から起きた browser だけで、普通に入れた Noraneko は触らないこと
- **やらないこと** ── 127.0.0.1 だけに立つ / 画面以外は URL の token を見る / 走らせられるのは `tools/launcher.rb` の表にある六つだけ / gem を使わない
- **転んだときの見かた** ── token 無しの URL、閉じない先客（`kill -9` で落とすと子が孤児になって profile の錠が残る）、押しても何も起きないときは launcher の端末を見る

`PORT=5199` で実際に立てて確かめました。

| | |
|---|---|
| `/`（token 無し） | 200（画面そのもの） |
| `/state`（token 無し） | 403 |
| `/state?t=…` | JSON が返る |
| LAN の IP から | つながらない（127.0.0.1 だけ） |

docs の相対リンクは全部生きています。

## 3. 切れていた RPC の行を、アクターの説明に

`docs/RPC_SYSTEM_README.md` は無いファイルでした。「Event Dispatcher / Inter-module communication system」という名前も、いま実際にあるものと合っていません。

アクターの説明は `browser-features/webext-actors/README.md` に 120 行あります（1 アクター = 1 ファイルの書きかた、三つの形、page ↔ content ↔ parent の道、build が何を生むか、omni と flat での登録、pref での二者択一、足しかた）。英語で二枚目を書くと必ずずれるので、行の指す先をそこにしました。docs/ 側に一枚ほしければ言ってください。

## 気づいたけれど直していないもの

`docs/ARCHITECTURE.md` に、いまと合っていないところが残っています ── 「Event Dispatcher - Event routing between modules」と、`lib/core/registry.ts`（もう無い）。`module_factory.ts` のほうは生きています。別の一枚として直すのが良さそうです。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwrruLhyKKN7A1iLU4YLdL
